### PR TITLE
feat: migra redlib para OCI container com podman

### DIFF
--- a/nix/nodes/common/services/redlib.nix
+++ b/nix/nodes/common/services/redlib.nix
@@ -9,6 +9,8 @@ let
   inherit (lib) mkEnableOption mkOption types mkIf mkDefault;
 in
 {
+  disabledModules = [ "services/misc/redlib.nix" ];
+
   options.services.redlib = {
     enable = mkEnableOption "redlib";
     image = mkOption {


### PR DESCRIPTION
Migra o serviço Redlib para container OCI usando Podman com pull always.

### Mudanças

- Substitui serviço NixOS nativo por container OCI
- Usa imagem oficial: `quay.io/redlib/redlib:latest`
- Configura `pull = "always"` para sempre baixar versão mais recente
- Mantém sistema de alocação automática de portas
- Exposto apenas em localhost (127.0.0.1)
- Configuração de ambiente: `REDLIB_DEFAULT_SHOW_NSFW=on`

Refs #65

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Serviço redlib agora configurável via opções públicas: habilitar, escolher imagem e definir porta.
  * Exposição do serviço via loopback com mapeamento de porta e variável de ambiente para conteúdo NSFW.
  * Integração automática com proxy reverso e suporte a TLS habilitado quando configurado.

* **Refatoração**
  * Migração para configuração condicional orientada por opções, simplificando ativação e personalização do serviço.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->