### PR TITLE
refactor(nix): share plymouth config between riverwood and whiterun

### DIFF
--- a/nix/nodes/common/plymouth.nix
+++ b/nix/nodes/common/plymouth.nix
@@ -1,0 +1,11 @@
+{ url, sha256 }:
+{ pkgs, ... }:
+{
+  boot.plymouth = {
+    enable = true;
+    theme = "breeze";
+    logo = pkgs.plymouthSvgLogo {
+      inherit url sha256;
+    };
+  };
+}

--- a/nix/nodes/riverwood/plymouth.nix
+++ b/nix/nodes/riverwood/plymouth.nix
@@ -1,11 +1,4 @@
-{ pkgs, ... }:
-{
-  boot.plymouth = {
-    enable = true;
-    theme = "breeze";
-    logo = pkgs.plymouthSvgLogo {
-      url = "https://static.wikia.nocookie.net/elderscrolls/images/7/74/SettlementWhite.svg";
-      sha256 = "00k9gm34i05rjia1ljglv7x3kp3a0q3kfv88dh8lar7hilq0w6l1";
-    };
-  };
+import ../common/plymouth.nix {
+  url = "https://static.wikia.nocookie.net/elderscrolls/images/7/74/SettlementWhite.svg";
+  sha256 = "00k9gm34i05rjia1ljglv7x3kp3a0q3kfv88dh8lar7hilq0w6l1";
 }

--- a/nix/nodes/whiterun/plymouth.nix
+++ b/nix/nodes/whiterun/plymouth.nix
@@ -1,11 +1,4 @@
-{ pkgs, ... }:
-{
-  boot.plymouth = {
-    enable = true;
-    theme = "breeze";
-    logo = pkgs.plymouthSvgLogo {
-      url = "https://static.wikia.nocookie.net/elderscrolls/images/6/64/Whiterun.svg";
-      sha256 = "1fqg4jk0ia1hp2mxvz9gxbxg337k4iwim9kbvdz4l99v886532g4";
-    };
-  };
+import ../common/plymouth.nix {
+  url = "https://static.wikia.nocookie.net/elderscrolls/images/6/64/Whiterun.svg";
+  sha256 = "1fqg4jk0ia1hp2mxvz9gxbxg337k4iwim9kbvdz4l99v886532g4";
 }


### PR DESCRIPTION
## Summary
Extract shared Plymouth module used by riverwood and whiterun. Host modules only pass logo `url` / `sha256`.

From `rft duplicates` low-hanging cluster (cross-host near-identical `boot.plymouth`).

## Changes
- Add `nix/nodes/common/plymouth.nix` parameterized by logo url/sha256
- Thin wrappers in riverwood/whiterun
- Recovery left alone

## Test plan
- [x] `nix eval '.#nixosConfigurations.riverwood.config.boot.plymouth.enable'` → true
- [x] `nix eval '.#nixosConfigurations.whiterun.config.boot.plymouth.enable'` → true
- [ ] Optional full `nixos-rebuild build --flake .#riverwood` / `.#whiterun`