### PR TITLE
feat(omarchy): package Quattro CLI and plugin host

### DIFF
--- a/nix/nodes/gui-common/default.nix
+++ b/nix/nodes/gui-common/default.nix
@@ -14,6 +14,7 @@ in
   imports = [
     ../common
     ./gui-variants
+    ./omarchy.nix
     ./audio.nix
     ./gui.nix
     ./networking.nix

--- a/nix/nodes/gui-common/gui-variants/hyprland/default.nix
+++ b/nix/nodes/gui-common/gui-variants/hyprland/default.nix
@@ -31,6 +31,7 @@
     services.gammastep.enable = true;
     programs.waybar.enable = true;
     programs.kdeconnect.enable = true;
+    programs.omarchy.enable = true;
 
     # https://github.com/loki-47-6F-64/sunshine/commit/ebf9dbe9318808a5e127d3b6e397b9fa5149f197.patch
     # programs.sunshine.package = pkgs.sunshine.overrideAttrs (old: {

--- a/nix/nodes/gui-common/gui-variants/sway/default.nix
+++ b/nix/nodes/gui-common/gui-variants/sway/default.nix
@@ -61,6 +61,7 @@ in
     services.gammastep.enable = true;
     programs.waybar.enable = true;
     programs.kdeconnect.enable = true;
+    programs.omarchy.enable = true;
 
     # System packages
     environment.systemPackages = with pkgs; [

--- a/nix/nodes/gui-common/omarchy.nix
+++ b/nix/nodes/gui-common/omarchy.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.omarchy;
+in
+{
+  options.programs.omarchy = {
+    enable = lib.mkEnableOption "Omarchy CLI, plugin manager, and optional Quickshell host";
+
+    package = lib.mkPackageOption pkgs "omarchy" { };
+
+    shell.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Start omarchy-shell (Quickshell) with the graphical session.
+        That process is what `omarchy plugin add` loads into.
+        On Sway you will have two bars until Waybar is turned off.
+        Workspace widgets that import Quickshell.Hyprland do not work on Sway.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      pkgs.quickshell
+    ];
+
+    environment.sessionVariables.OMARCHY_PATH = "${cfg.package}/share/omarchy";
+
+    systemd.user.services.omarchy-shell = lib.mkIf cfg.shell.enable {
+      description = "Omarchy Quickshell desktop host";
+      partOf = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      restartIfChanged = true;
+      path = [
+        cfg.package
+        pkgs.quickshell
+        pkgs.jq
+        pkgs.gum
+        pkgs.git
+      ]
+      ++ lib.optional config.programs.sway.enable pkgs.sway
+      ++ lib.optional config.programs.hyprland.enable config.programs.hyprland.package;
+      environment = {
+        OMARCHY_PATH = "${cfg.package}/share/omarchy";
+      };
+      script = "exec ${lib.getExe' cfg.package "omarchy-launch-shell"}";
+    };
+  };
+}

--- a/nix/nodes/gui-common/omarchy.nix
+++ b/nix/nodes/gui-common/omarchy.nix
@@ -7,6 +7,11 @@
 
 let
   cfg = config.programs.omarchy;
+  omarchyIconFont = pkgs.runCommand "omarchy-icon-font" { } ''
+    mkdir -p $out/share/fonts/truetype
+    cp ${cfg.package}/share/omarchy/default/fonts/omarchy/omarchy.ttf \
+      $out/share/fonts/truetype/omarchy.ttf
+  '';
 in
 {
   options.programs.omarchy = {
@@ -30,9 +35,19 @@ in
     environment.systemPackages = [
       cfg.package
       pkgs.quickshell
+      pkgs.yaru-theme
     ];
 
     environment.sessionVariables.OMARCHY_PATH = "${cfg.package}/share/omarchy";
+
+    # Bar glyphs are Nerd Font / omarchy.ttf PUA. Stock monospace here is
+    # DejaVu, which has none of those codepoints.
+    fonts.packages = [
+      pkgs.nerd-fonts.jetbrains-mono
+      pkgs.liberation_ttf
+      omarchyIconFont
+    ];
+    fonts.fontconfig.defaultFonts.monospace = lib.mkBefore [ "JetBrainsMono Nerd Font" ];
 
     systemd.user.services.omarchy-shell = lib.mkIf cfg.shell.enable {
       description = "Omarchy Quickshell desktop host";
@@ -46,13 +61,17 @@ in
         pkgs.jq
         pkgs.gum
         pkgs.git
+        pkgs.fontconfig
       ]
       ++ lib.optional config.programs.sway.enable pkgs.sway
       ++ lib.optional config.programs.hyprland.enable config.programs.hyprland.package;
       environment = {
         OMARCHY_PATH = "${cfg.package}/share/omarchy";
       };
-      script = "exec ${lib.getExe' cfg.package "omarchy-launch-shell"}";
+      script = ''
+        export XDG_DATA_DIRS="${pkgs.yaru-theme}/share:${pkgs.adwaita-icon-theme}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+        exec ${lib.getExe' cfg.package "omarchy-launch-shell"}
+      '';
     };
   };
 }

--- a/nix/nodes/gui-common/omarchy.nix
+++ b/nix/nodes/gui-common/omarchy.nix
@@ -70,6 +70,14 @@ in
       };
       script = ''
         export XDG_DATA_DIRS="${pkgs.yaru-theme}/share:${pkgs.adwaita-icon-theme}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+        if [ -z "''${SWAYSOCK:-}" ]; then
+          for sock in "''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"/sway-ipc.*.sock; do
+            if [ -S "$sock" ]; then
+              export SWAYSOCK="$sock"
+              break
+            fi
+          done
+        fi
         exec ${lib.getExe' cfg.package "omarchy-launch-shell"}
       '';
     };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -111,6 +111,8 @@ in
     inherit (flake) colors;
   };
 
+  omarchy = final.callPackage ./pkgs/omarchy.nix { };
+
   script-directory-wrapper = final.writeShellScriptBin "sdw" ''
     set -eu
     export SD_CMD=

--- a/nix/pkgs/omarchy-Workspaces.qml
+++ b/nix/pkgs/omarchy-Workspaces.qml
@@ -1,0 +1,110 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Hyprland
+import Quickshell.I3
+import qs.Commons
+import qs.Ui
+
+BarWidget {
+  id: root
+  moduleName: "omarchy.workspaces"
+
+  readonly property bool useI3: {
+    var sway = Quickshell.env("SWAYSOCK")
+    var i3 = Quickshell.env("I3SOCK")
+    return (sway && sway.length > 0) || (i3 && i3.length > 0)
+  }
+
+  function workspaceEntries() {
+    return root.useI3 ? I3.workspaces.values : Hyprland.workspaces.values
+  }
+
+  function workspaceNumber(workspace) {
+    if (workspace === null)
+      return -1
+    return root.useI3 ? workspace.number : workspace.id
+  }
+
+  function workspaceByNumber(id) {
+    var values = root.workspaceEntries()
+    for (var i = 0; i < values.length; i++) {
+      if (root.workspaceNumber(values[i]) === id)
+        return values[i]
+    }
+    return null
+  }
+
+  function workspaceIds() {
+    var ids = [1, 2, 3, 4, 5]
+    var values = root.workspaceEntries()
+
+    for (var i = 0; i < values.length; i++) {
+      var id = root.workspaceNumber(values[i])
+      if (id > 0 && id <= 10 && ids.indexOf(id) === -1)
+        ids.push(id)
+    }
+
+    ids.sort(function (left, right) { return left - right })
+    return ids
+  }
+
+  function focusedWorkspaceNumber() {
+    if (root.useI3)
+      return I3.focusedWorkspace !== null ? I3.focusedWorkspace.number : -1
+    return Hyprland.focusedWorkspace !== null ? Hyprland.focusedWorkspace.id : -1
+  }
+
+  function workspaceOccupied(workspace) {
+    if (workspace === null)
+      return false
+    if (root.useI3)
+      return true
+    return workspace.toplevels.values.length > 0
+  }
+
+  function focusWorkspace(id) {
+    if (root.useI3) {
+      I3.dispatch("workspace number " + id)
+      return
+    }
+    if (!root.bar)
+      return
+    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+  }
+
+  readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)
+
+  implicitWidth: grid.implicitWidth + trailingGap
+  implicitHeight: grid.implicitHeight
+
+  GridLayout {
+    id: grid
+    anchors.fill: parent
+    anchors.rightMargin: root.trailingGap
+    columns: root.vertical ? 1 : root.workspaceIds().length
+    columnSpacing: root.vertical ? 0 : Style.space(1)
+    rowSpacing: root.vertical ? Style.space(2) : 0
+
+    Repeater {
+      model: root.workspaceIds()
+
+      WidgetButton {
+        required property int modelData
+
+        readonly property var workspace: root.workspaceByNumber(modelData)
+        readonly property bool occupied: root.workspaceOccupied(workspace)
+        readonly property bool focused: root.focusedWorkspaceNumber() === modelData
+
+        bar: root.bar
+        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        opacity: occupied || focused ? 1 : 0.5
+        horizontalMargin: 6
+        verticalPadding: 6
+        fixedWidth: root.vertical ? root.barSize : Style.space(20)
+        fixedHeight: root.barSize
+        onPressed: function () { root.focusWorkspace(modelData) }
+      }
+    }
+  }
+}

--- a/nix/pkgs/omarchy.nix
+++ b/nix/pkgs/omarchy.nix
@@ -33,12 +33,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontConfigure = true;
   dontBuild = true;
 
-  # Upstream launcher only probes Hyprland. Keep hyprctl, also accept Sway.
+  # Upstream launcher and workspace widget are Hyprland-only. Keep hyprctl,
+  # accept Sway, and drive workspaces through Quickshell.I3 when SWAYSOCK is set.
   postPatch = ''
     substituteInPlace bin/omarchy-launch-shell \
       --replace-fail 'hyprctl -j monitors >/dev/null 2>&1 && return 0' \
       'if command -v hyprctl >/dev/null && hyprctl -j monitors >/dev/null 2>&1; then return 0; fi
         if command -v swaymsg >/dev/null && swaymsg -t get_outputs >/dev/null 2>&1; then return 0; fi'
+    cp ${./omarchy-Workspaces.qml} shell/plugins/bar/widgets/Workspaces.qml
   '';
 
   installPhase = ''

--- a/nix/pkgs/omarchy.nix
+++ b/nix/pkgs/omarchy.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  bash,
+  coreutils,
+  findutils,
+  gawk,
+  git,
+  gnugrep,
+  gnused,
+  gum,
+  jq,
+  procps,
+  quickshell,
+  systemd,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "omarchy";
+  version = "4.0.0-unstable-2026-08-15";
+
+  src = fetchFromGitHub {
+    owner = "basecamp";
+    repo = "omarchy";
+    rev = "f32ebbdb730c4e8fe11e4046cef4267e466264ea";
+    hash = "sha256-uBoJVjt0l/iERvd48GJdEER+fvYfvZL70MetWYcj/TM=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Upstream launcher only probes Hyprland. Keep hyprctl, also accept Sway.
+  postPatch = ''
+    substituteInPlace bin/omarchy-launch-shell \
+      --replace-fail 'hyprctl -j monitors >/dev/null 2>&1 && return 0' \
+      'if command -v hyprctl >/dev/null && hyprctl -j monitors >/dev/null 2>&1; then return 0; fi
+        if command -v swaymsg >/dev/null && swaymsg -t get_outputs >/dev/null 2>&1; then return 0; fi'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/omarchy $out/bin
+    cp -a bin shell default themes version $out/share/omarchy/
+    for extra in icon.png icon.txt logo.svg logo.txt LICENSE; do
+      if [ -e "$extra" ]; then
+        cp -a "$extra" $out/share/omarchy/
+      fi
+    done
+    if [ -d config ]; then
+      cp -a config $out/share/omarchy/
+    fi
+    if [ -d applications ]; then
+      cp -a applications $out/share/omarchy/
+    fi
+
+    runtime=${lib.makeBinPath [
+      bash
+      coreutils
+      findutils
+      gawk
+      git
+      gnugrep
+      gnused
+      gum
+      jq
+      procps
+      quickshell
+      systemd
+    ]}
+
+    for src in $out/share/omarchy/bin/omarchy $out/share/omarchy/bin/omarchy-*; do
+      [ -f "$src" ] && [ -x "$src" ] || continue
+      name=$(basename "$src")
+      makeWrapper "$src" "$out/bin/$name" \
+        --set OMARCHY_PATH "$out/share/omarchy" \
+        --prefix PATH : "$out/bin:$runtime"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Omarchy Quattro CLI, plugin manager, and Quickshell desktop host";
+    homepage = "https://github.com/basecamp/omarchy";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "omarchy";
+  };
+})


### PR DESCRIPTION
**This is the Omarchy tooling, not another Waybar widget.**

#462 was the wrong slice. Plugins run inside `omarchy-shell` (Quickshell). This PR puts that host and the `omarchy` CLI on this NixOS/Sway tree.

## What you get after rebuild
- `omarchy` / `omarchy plugin add|list|validate|enable|remove`
- First-party plugin tree (37 manifests) under `$OMARCHY_PATH/shell/plugins`
- `systemd --user` unit `omarchy-shell` (on by default on Sway and Hyprland)
- Launcher accepts `swaymsg` as well as `hyprctl`

Verified here: package builds, `omarchy plugin --help` works, catalog lists 37 plugins, `omarchy plugin list` correctly reports the shell is not running until the user service starts.

## Apply
```
sudo nixos-rebuild switch --flake .
omarchy plugin --help
omarchy plugin add https://github.com/jitendradara12/omaconnect.git --yes
```

## Limits (on purpose)
- Workspace widgets import `Quickshell.Hyprland`. They will not work on Sway.
- `omarchy update` / pacman installers still assume Arch. Do not run those.
- Default starts the shell **and** keeps Waybar. Two bars until you set `programs.waybar.enable = false` or `programs.omarchy.shell.enable = false`.

## Toggle
```
programs.omarchy.enable = true;           # already set on Sway/Hyprland
programs.omarchy.shell.enable = false;    # CLI only
```